### PR TITLE
ci: enforce consistent line endings and configure git EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Enforce LF for all text files
+* text=auto eol=lf
+
+# Keep Windows command scripts with CRLF line endings
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure git EOL (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          git config core.autocrlf false
+          git config core.eol lf
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
     "indentStyle": "space",
     "indentWidth": 4,
     "lineWidth": 120,
-    "bracketSpacing": false
+    "bracketSpacing": false,
+    "lineEnding": "lf"
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
- Added `.gitattributes` to enforce LF line endings for text files while retaining CRLF for scripts.
- Updated `ci.yml` to configure git EOL settings explicitly for Windows runners.
- Modified `biome.json` to specify LF as the default line ending.